### PR TITLE
fix: exclude mermaid documentation generation on Windows

### DIFF
--- a/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
+++ b/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs
@@ -57,7 +57,7 @@ type UncheckedSignaturePayload<Address, Signature, Extra> = (Address, Signature,
 /// could in principle be any other interaction. Transactions are either signed or unsigned. A
 /// sensible transaction pool should ensure that only transactions that are worthwhile are
 /// considered for block-building.
-#[cfg_attr(feature = "std", doc = simple_mermaid::mermaid!("../../docs/mermaid/extrinsics.mmd"))]
+#[cfg_attr(all(feature = "std", not(windows)), doc = simple_mermaid::mermaid!("../../docs/mermaid/extrinsics.mmd"))]
 /// This type is by no means enforced within Substrate, but given its genericness, it is highly
 /// likely that for most use-cases it will suffice. Thus, the encoding of this type will dictate
 /// exactly what bytes should be sent to a runtime to transact with it.


### PR DESCRIPTION
[This](https://github.com/availproject/polkadot-sdk/blob/822082807fd6f146cd1c0561dc340dedab463c40/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs#L60) line causes the build process for the avail-light to fail on windows. 

Took inspiration from the [main repo](https://github.com/paritytech/polkadot-sdk/blob/2460cddf57660a88844d201f769eb17a7accce5a/substrate/primitives/runtime/src/generic/unchecked_extrinsic.rs#L60) to fix the build process. Thanks! 