### PR TITLE
grandpa: ensure voting doesn't fail after a re-org

### DIFF
--- a/substrate/client/consensus/grandpa/src/environment.rs
+++ b/substrate/client/consensus/grandpa/src/environment.rs
@@ -1217,14 +1217,20 @@ where
 			.header(target_hash)?
 			.expect("Header known to exist after `finality_target` call; qed"),
 		Err(err) => {
-			warn!(
+			debug!(
 				target: LOG_TARGET,
 				"Encountered error finding best chain containing {:?}: couldn't find target block: {}",
 				block,
 				err,
 			);
 
-			return Ok(None)
+			// NOTE: in case the given `SelectChain` doesn't provide any block we fallback to using
+			// the given base block provided by the GRANDPA voter.
+			//
+			// For example, `LongestChain` will error if the given block to use as base isn't part
+			// of the best chain (as defined by `LongestChain`), which could happen if there was a
+			// re-org.
+			base_header.clone()
 		},
 	};
 


### PR DESCRIPTION
This fixes the potential finality stall issue after reorgs.
ref: https://github.com/paritytech/polkadot-sdk/pull/5153
